### PR TITLE
Remove dist folder from .distignore

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -43,7 +43,6 @@ yarn.lock
 .wordpress-org
 .github
 LICENSE.md
-dist
 .babelrc
 DOCKER_ENV
 docker_tag


### PR DESCRIPTION
Should fix the plugin on wp.org